### PR TITLE
Improve react-query caching

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Blue Bike Data</title>
+    <title>Bluebike Data</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
       queries: {
         refetchOnWindowFocus: false,
         retry: 0,
-        staleTime: 10000, // 10 seconds
+        staleTime: Infinity,
       },
     },
   });

--- a/src/api/all_data.ts
+++ b/src/api/all_data.ts
@@ -60,10 +60,8 @@ export const useMonthlyData = (
     type = 1;
   }
 
-  const data = useQuery(
-    [year, month],
-    () => fetchMonthlyDestinations(year, month),
-    { staleTime: Infinity }
+  const data = useQuery([year, month], () =>
+    fetchMonthlyDestinations(year, month)
   );
 
   const nextMonth = {
@@ -79,7 +77,6 @@ export const useMonthlyData = (
       enabled:
         nextMonth.year < CURRENT_MAX.year ||
         nextMonth.month <= CURRENT_MAX.month,
-      staleTime: Infinity,
     }
   );
 

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -61,11 +61,11 @@ export const InfoModal = () => {
                     as="h3"
                     className="text-lg font-medium leading-6 "
                   >
-                    Blue Bike Data
+                    Bluebike Data
                   </Dialog.Title>
                   <div className="mt-2">
                     <p className="text-sm ">
-                      Use this tool to discover insights into Blue Bike
+                      Use this tool to discover insights into Bluebike
                       ridership.
                     </p>
                     <br />
@@ -85,8 +85,9 @@ export const InfoModal = () => {
                         <FontAwesomeIcon
                           icon={faCircle}
                           className="text-sky-400 opacity-60"
-                        /> will inflate according to the number of trips which end at that dock.
-
+                        />{" "}
+                        will inflate according to the number of trips which end
+                        at that dock.
                       </li>
                       <li>hover over a dock to see exact numbers.</li>
                     </ul>

--- a/src/maps/DockMarkerFactory.tsx
+++ b/src/maps/DockMarkerFactory.tsx
@@ -16,7 +16,7 @@ export const StationMarkerFactory: React.FC<{
   const configStore = useConfigStore((store) => store);
   const { selectedDocks, isDrawing, setOrClearSingleDock, deleteShape, shape, setBothShapeArea, shapeArea } = useSelectionStore((store) => store);
   const currentShapeArea = useShapeArea();
-  const all_docks = useQuery(["all_docks"], () => fetchAllDocks(), {staleTime: Infinity});
+  const all_docks = useQuery(["all_docks"], () => fetchAllDocks());
   useEffect(() => {
     setShapeAreas(shape, setBothShapeArea)
   }, [shape, setBothShapeArea])

--- a/src/maps/DockMarkerFactory.tsx
+++ b/src/maps/DockMarkerFactory.tsx
@@ -16,7 +16,7 @@ export const StationMarkerFactory: React.FC<{
   const configStore = useConfigStore((store) => store);
   const { selectedDocks, isDrawing, setOrClearSingleDock, deleteShape, shape, setBothShapeArea, shapeArea } = useSelectionStore((store) => store);
   const currentShapeArea = useShapeArea();
-  const all_docks = useQuery(["all_docks"], () => fetchAllDocks());
+  const all_docks = useQuery(["all_docks"], () => fetchAllDocks(), {staleTime: Infinity});
   useEffect(() => {
     setShapeAreas(shape, setBothShapeArea)
   }, [shape, setBothShapeArea])


### PR DESCRIPTION
Stale time doesn't need to be 10 seconds. It was making the prefetch useless if you linger on a month for more than 10 seconds. Also, now if you rewatch the animation it won't refetch everything and it smoother